### PR TITLE
fix line 174:print in reverse order the fields of every line

### DIFF
--- a/awk1line.txt
+++ b/awk1line.txt
@@ -171,7 +171,7 @@ TEXT CONVERSION AND SUBSTITUTION:
  awk '{ $2 = ""; print }'
 
  # print in reverse order the fields of every line
- awk '{for (i=NF; i>0; i--) printf("%s ",i);printf ("\n")}' file
+ awk '{for (i=NF; i>0; i--) printf("%s ",$i);printf ("\n")}' file
 
  # remove duplicate, consecutive lines (emulates "uniq")
  awk 'a !~ $0; {a=$0}'


### PR DESCRIPTION
Line 174 as is just prints the field numbers, a variable reference gives the expected behaviour.
Example:

$ echo "a b c\nd e f" | awk '{for (i=NF; i>0; i--) printf("%s ",i);printf ("\n")}'
3 2 1
3 2 1

$ echo "a b c\nd e f" | awk '{for (i=NF; i>0; i--) printf("%s ",$i);printf ("\n")}'
c b a
f e d